### PR TITLE
Archive page formatting01

### DIFF
--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -47,7 +47,7 @@ function App() {
           <Route
             // shows GalleryPage at all times (logged in or not)
             exact
-            path="/gallery"
+            path="/archive"
           >
             <GalleryPage />
           </Route>

--- a/src/components/GalleryPage/GalleryEnlargeModal.jsx
+++ b/src/components/GalleryPage/GalleryEnlargeModal.jsx
@@ -7,15 +7,16 @@ const GalleryEnlargeModal = ({ selectedItem, isOpen, setIsOpen }) => {
     // Function to handle modal close
     const onClose = () => setIsOpen(false);
 
-    const NoteType = ({ selectedItem }) => {
+    const GridLayout = ({ selectedItem, mediaComponent }) => {
         return (
-            <Grid container padding={'20px'}>
-                <Grid item xs={4} sx={{ alignContent: 'center', justifyItems: 'center', overflow: 'scroll' }}>
-                    <Typography variant='body2'>
+            <Grid container padding={'20px'} gap={2}>
+                <Grid item xs={3} sx={{ alignContent: 'center', justifyItems: 'center', overflow: 'scroll' }}>
+                    {!mediaComponent && <Typography variant='body2'>
                         No media to display.
-                    </Typography>
+                    </Typography>}
+                    {mediaComponent}
                 </Grid>
-                <Grid item xs={8}>
+                <Grid item xs={7}>
                     <Typography
                         variant="h5"
                         component="div"
@@ -62,15 +63,18 @@ const GalleryEnlargeModal = ({ selectedItem, isOpen, setIsOpen }) => {
 
         switch (media_type) {
             case 1: // Notes only, no media to display
-                return <NoteType selectedItem={selectedItem} />
+                return <GridLayout selectedItem={selectedItem} />
             case 3: // Video
                 return (
-                    <div style={{ textAlign: "center" }}>
-                        <video src={aws_url} controls style={{ maxHeight: "500px", maxWidth: "100%", objectFit: "contain" }} />
-                        <Typography style={{ marginTop: "20px" }}>{notes}</Typography>
-                    </div>
+                    <GridLayout selectedItem={selectedItem} mediaComponent={(
+                        <video
+                            src={aws_url}
+                            controls
+                            style={{ width: '100%' }}
+                        />
+                    )} />
                 );
-            case 4: // Audio
+            case 4: // ! Audio is broken, renders with video
                 return (
                     <div style={{ textAlign: "center" }}>
                         <audio src={aws_url} controls style={{ maxWidth: "100%" }} />
@@ -79,10 +83,9 @@ const GalleryEnlargeModal = ({ selectedItem, isOpen, setIsOpen }) => {
                 );
             default: // Images
                 return (
-                    <div style={{ textAlign: "center" }}>
+                    <GridLayout selectedItem={selectedItem} mediaComponent={(
                         <img src={aws_url} alt="Archive item" style={{ maxHeight: "500px", maxWidth: "100%", objectFit: "contain" }} />
-                        <Typography style={{ marginTop: "20px" }}>{notes}</Typography>
-                    </div>
+                    )} />
                 );
         }
     };

--- a/src/components/GalleryPage/GalleryEnlargeModal.jsx
+++ b/src/components/GalleryPage/GalleryEnlargeModal.jsx
@@ -30,7 +30,7 @@ const GalleryEnlargeModal = ({ selectedItem, isOpen, setIsOpen }) => {
             default: // Images
                 return (
                     <div style={{ textAlign: "center" }}>
-                        <img src={aws_url} alt="Gallery item" style={{ maxHeight: "500px", maxWidth: "100%", objectFit: "contain" }} />
+                        <img src={aws_url} alt="Archive item" style={{ maxHeight: "500px", maxWidth: "100%", objectFit: "contain" }} />
                         <Typography style={{ marginTop: "20px" }}>{notes}</Typography>
                     </div>
                 );

--- a/src/components/GalleryPage/GalleryEnlargeModal.jsx
+++ b/src/components/GalleryPage/GalleryEnlargeModal.jsx
@@ -1,18 +1,68 @@
 import React from 'react';
-import { Dialog, DialogContent, Typography } from '@mui/material';
+import { Dialog, DialogContent, Grid, Typography, Avatar } from '@mui/material';
+import { DateTime } from "luxon";
 
 // Functional component for enlarging gallery items in a modal
 const GalleryEnlargeModal = ({ selectedItem, isOpen, setIsOpen }) => {
     // Function to handle modal close
     const onClose = () => setIsOpen(false);
 
+    const NoteType = ({ selectedItem }) => {
+        return (
+            <Grid container padding={'20px'}>
+                <Grid item xs={4} sx={{ alignContent: 'center', justifyItems: 'center', overflow: 'scroll' }}>
+                    <Typography variant='body2'>
+                        No media to display.
+                    </Typography>
+                </Grid>
+                <Grid item xs={8}>
+                    <Typography
+                        variant="h5"
+                        component="div"
+                        sx={{ textAlign: "center", margin: "12px 0" }}
+                    >
+                        {selectedItem.title}
+                    </Typography>
+                    <Typography
+                        variant="body2"
+                        color="text.secondary"
+                    >
+                        {selectedItem.notes}
+                    </Typography>
+                    <div className="user-info" style={{ marginTop: '10px' }}>
+                        <Typography
+                            variant="body2"
+                        >
+                            Submitted by: {selectedItem.username}
+                        </Typography>
+                        <Avatar
+                            alt={selectedItem.username}
+                            src={selectedItem.avatar_AWS_URL || "./altered_avi2.jpeg"}
+                            sizes="small"
+                        />
+                        <Typography
+                            variant="body2"
+                        >
+                            {DateTime.fromISO(selectedItem.date_posted).toLocaleString(DateTime.DATETIME_MED)}
+                        </Typography>
+                        <Typography
+                            variant="body2"
+                        >
+                            {selectedItem.location}
+                        </Typography>
+                    </div>
+                </Grid>
+            </Grid>
+        )
+    }
+
     // Function to determine and render content based on media type
     const renderContent = () => {
         const { media_type, aws_url, notes } = selectedItem;
 
-        switch(media_type) {
+        switch (media_type) {
             case 1: // Notes only, no media to display
-                return <Typography style={{ marginTop: "20px" }}>{notes}</Typography>;
+                return <NoteType selectedItem={selectedItem} />
             case 3: // Video
                 return (
                     <div style={{ textAlign: "center" }}>
@@ -37,7 +87,6 @@ const GalleryEnlargeModal = ({ selectedItem, isOpen, setIsOpen }) => {
         }
     };
 
-    // JSX for rendering the modal
     return (
         <Dialog open={isOpen} onClose={onClose} fullWidth maxWidth="md">
             <DialogContent style={{ padding: 0 }}>{selectedItem && renderContent()}</DialogContent>
@@ -45,4 +94,4 @@ const GalleryEnlargeModal = ({ selectedItem, isOpen, setIsOpen }) => {
     );
 };
 
-export default GalleryEnlargeModal; // Exporting the component
+export default GalleryEnlargeModal;

--- a/src/components/GalleryPage/GalleryPage.jsx
+++ b/src/components/GalleryPage/GalleryPage.jsx
@@ -16,12 +16,12 @@ function GalleryPage() {
     }, []);
 
     // Function to handle page change in pagination
-    const handleChange = (event, value) => {
+    const handleChange = (_event, value) => {
         setPage(value);
     };
 
     // Function to handle media filter change
-    const handleMediaFilterChange = (event, newMediaType) => {
+    const handleMediaFilterChange = (_event, newMediaType) => {
         setSelectedCategories(newMediaType);
     };
 
@@ -66,7 +66,6 @@ function GalleryPage() {
     } else {
         return (
             <div style={{ padding: "65px 0" }}>
-                {/* <h2 style={{ leftPadding: "65px", padding: "5px" }} >Evidence Gallery: Declassified</h2> */}
                 <MediaFilter selectedMediaType={selectedMediaType} onMediaTypeChange={handleMediaFilterChange} />
                 <Grid container spacing={2} justifyContent="center" style={{ padding: "20px" }}>
                     {getFilteredEvidence()[`page${page}`]?.map((item) => (

--- a/src/components/GalleryPage/GalleryPage.jsx
+++ b/src/components/GalleryPage/GalleryPage.jsx
@@ -36,7 +36,7 @@ function GalleryPage() {
 
     // Function to paginate results
     const paginateResults = (array) => {
-        const itemsPerPage = 8; // 2 rows of 4
+        const itemsPerPage = 15; // 2 rows of 4
         let pages = {};
         
         array.forEach((item, index) => {
@@ -67,7 +67,7 @@ function GalleryPage() {
         return (
             <div style={{ padding: "65px 0" }}>
                 <MediaFilter selectedMediaType={selectedMediaType} onMediaTypeChange={handleMediaFilterChange} />
-                <Grid container spacing={2} justifyContent="center" style={{ padding: "20px" }}>
+                <Grid container spacing={2} justifyContent='flex-start' style={{ padding: "20px" }}>
                     {getFilteredEvidence()[`page${page}`]?.map((item) => (
                         <GalleryPageEvCard item={item} key={item.id} />
                     ))}

--- a/src/components/GalleryPage/GalleryPageEvCard.jsx
+++ b/src/components/GalleryPage/GalleryPageEvCard.jsx
@@ -5,7 +5,8 @@ import {
     Grid,
     Card,
     Typography,
-    CardContent
+    CardContent,
+    CardMedia,
 } from '@mui/material';
 import GalleryEnlargeModal from './GalleryEnlargeModal';
 
@@ -28,14 +29,14 @@ export const GalleryPageEvCard = ({ item }) => {
         overflow: 'hidden',
         textOverflow: 'ellipsis',
         display: '-webkit-box',
-        WebkitLineClamp: 3, // Number of lines you want to display
+        WebkitLineClamp: 6, // Number of lines you want to display
         WebkitBoxOrient: 'vertical',
         fontSize: '1rem', // Larger font size
     };
 
     return (
         <>
-            <Grid key={item.id} item xs={12} sm={10} md={6} lg={3}>
+            {/* <Grid key={item.id} item xs={12} sm={10} md={6} lg={3}>
                 <Card
                     className="item-card"
                     sx={{
@@ -136,6 +137,59 @@ export const GalleryPageEvCard = ({ item }) => {
                         {item.location}
                     </Typography>
                 </Card>
+            </Grid> */}
+            <Grid item xs={4} sx={{ justifyItems: 'center' }} >
+                <div onClick={() => setIsOpen(true)} style={{ width: '250px', height: '357px' }}>
+                    {/* // TODO audio not rendering correctly */}
+                    {isAudio && (
+                        <>
+                            <div style={{ width: "55%", alignSelf: "center", marginBottom: "-40px" }}>
+                                <img
+                                    src='./audio_placeholder.jpeg'
+                                    alt="Audio Placeholder"
+                                    style={{ width: "100%", height: 130, objectFit: "cover" }}
+                                />
+                            </div>
+                            <audio
+                                ref={audioRef}
+                                src={item.aws_url}
+                                controls
+                                style={{ width: "60%", alignSelf: "center", marginTop: "10px" }}
+                            />
+                        </>
+                    )}
+                    {isVideo && (
+                        <video
+                            src={item.aws_url}
+                            controls
+                            style={{
+                                height: 200,
+                                minWidth: 250,
+                                objectFit: "cover",
+                                alignSelf: "center",
+                            }}
+                        />
+                    )}
+                    {!isAudio && !isVideo && !isNote && (
+                        <img
+                            src={item.aws_url}
+                            alt={item.title}
+                            style={{
+                                height: 200,
+                                minWidth: '250px',
+                                objectFit: "cover",
+                                alignSelf: "center",
+                            }}
+                        />
+                    )}
+                    <Typography
+                        variant="body2"
+                        color="text.secondary"
+                        sx={noteStyles}
+                    >
+                        {item.notes}
+                    </Typography>
+                </div>
             </Grid>
 
             <GalleryEnlargeModal isOpen={isOpen} setIsOpen={setIsOpen} selectedItem={item} />

--- a/src/components/GalleryPage/GalleryPageEvCard.jsx
+++ b/src/components/GalleryPage/GalleryPageEvCard.jsx
@@ -1,12 +1,7 @@
 import React, { useState, useRef } from "react";
-import { DateTime } from "luxon";
 import {
-    Avatar,
     Grid,
-    Card,
     Typography,
-    CardContent,
-    CardMedia,
 } from '@mui/material';
 import GalleryEnlargeModal from './GalleryEnlargeModal';
 
@@ -36,108 +31,6 @@ export const GalleryPageEvCard = ({ item }) => {
 
     return (
         <>
-            {/* <Grid key={item.id} item xs={12} sm={10} md={6} lg={3}>
-                <Card
-                    className="item-card"
-                    sx={{
-                        display: "flex",
-                        flexDirection: "column",
-                        position: "relative",
-                        height: 450,
-                    }}
-                    onClick={() => setIsOpen(true)}
-                >
-                    <Typography
-                        variant="h5"
-                        component="div"
-                        sx={{ textAlign: "center", margin: "12px 0" }}
-                    >
-                        {item.title}
-                    </Typography>
-                    <hr style={{ width: '100%', alignSelf: 'center' }} />
-                    {isAudio && (
-                        <>
-                            <div style={{ width: "55%", alignSelf: "center", marginBottom: "-40px" }}>
-                                <img
-                                    src='./audio_placeholder.jpeg'
-                                    alt="Audio Placeholder"
-                                    style={{ width: "100%", height: 130, objectFit: "cover" }}
-                                />
-                            </div>
-                            <audio
-                                ref={audioRef}
-                                src={item.aws_url}
-                                controls
-                                style={{ width: "60%", alignSelf: "center", marginTop: "10px" }}
-                            />
-                            <hr style={{ width: '100%', alignSelf: 'center' }} />
-                        </>
-                    )}
-                    {isVideo && (
-                        <>
-                            <video
-                                src={item.aws_url}
-                                controls
-                                style={{
-                                    height: 160,
-                                    width: "80%",
-                                    objectFit: "cover",
-                                    alignSelf: "center",
-                                }}
-                            />
-                            <hr style={{ width: '100%', alignSelf: 'center' }} />
-                        </>
-                    )}
-                    {!isAudio && !isVideo && !isNote && (
-                        <>
-                            <img
-                                src={item.aws_url}
-                                alt={item.title}
-                                style={{
-                                    height: 160,
-                                    width: "80%",
-                                    objectFit: "cover",
-                                    alignSelf: "center",
-                                }}
-                            />
-                            <hr style={{ width: '100%', alignSelf: 'center' }} />
-                        </>
-                    )}
-                    <CardContent sx={{ flexGrow: 1, width: "100%" }}>
-                        <Typography
-                            variant="body2"
-                            color="text.secondary"
-                            sx={noteStyles} // Apply custom styles for ellipsis and larger font
-                        >
-                            {item.notes}
-                        </Typography>
-                    </CardContent>
-                    <Typography
-                        variant="body2"
-                        sx={{ position: "absolute", bottom: 30, left: 10 }}
-                    >
-                        Submitted by: {item.username}
-                    </Typography>
-                    <Avatar
-                        alt={item.username}
-                        src={item.avatar_AWS_URL || "./altered_avi2.jpeg"}
-                        sizes="small"
-                        sx={{ position: 'absolute', bottom: 55, left: 11 }}
-                    />
-                    <Typography
-                        variant="body2"
-                        sx={{ position: "absolute", bottom: 10, left: 10 }}
-                    >
-                        {DateTime.fromISO(item.date_posted).toLocaleString(DateTime.DATETIME_MED)}
-                    </Typography>
-                    <Typography
-                        variant="body2"
-                        sx={{ position: "absolute", bottom: 10, right: 10 }}
-                    >
-                        {item.location}
-                    </Typography>
-                </Card>
-            </Grid> */}
             <Grid item xs={12} sm={6} md={4} sx={{ justifyItems: 'center' }} >
                 <div onClick={() => setIsOpen(true)} style={{ width: '250px', height: '357px' }}>
                     {/* // TODO audio not rendering correctly */}

--- a/src/components/GalleryPage/GalleryPageEvCard.jsx
+++ b/src/components/GalleryPage/GalleryPageEvCard.jsx
@@ -138,7 +138,7 @@ export const GalleryPageEvCard = ({ item }) => {
                     </Typography>
                 </Card>
             </Grid> */}
-            <Grid item xs={4} sx={{ justifyItems: 'center' }} >
+            <Grid item xs={12} sm={6} md={4} sx={{ justifyItems: 'center' }} >
                 <div onClick={() => setIsOpen(true)} style={{ width: '250px', height: '357px' }}>
                     {/* // TODO audio not rendering correctly */}
                     {isAudio && (

--- a/src/components/Nav/Nav.jsx
+++ b/src/components/Nav/Nav.jsx
@@ -89,7 +89,7 @@ function Nav() {
                 <MenuItem onClick={() => navigateTo('/home')} sx={menuItemStyle}>
                   Home
                 </MenuItem>
-                <MenuItem onClick={() => navigateTo('/gallery')} sx={menuItemStyle}>
+                <MenuItem onClick={() => navigateTo('/archive')} sx={menuItemStyle}>
                   Archive
                 </MenuItem>
                 <MenuItem onClick={() => navigateTo('/registration')} sx={menuItemStyle}>
@@ -112,7 +112,7 @@ function Nav() {
                     Admin Page
                   </MenuItem>
                 )}
-                <MenuItem onClick={() => navigateTo('/gallery')} sx={menuItemStyle}>
+                <MenuItem onClick={() => navigateTo('/archive')} sx={menuItemStyle}>
                   Archive
                 </MenuItem>
                 <MenuItem onClick={() => navigateTo('/help')} sx={menuItemStyle}>

--- a/src/components/Nav/Nav.jsx
+++ b/src/components/Nav/Nav.jsx
@@ -90,7 +90,7 @@ function Nav() {
                   Home
                 </MenuItem>
                 <MenuItem onClick={() => navigateTo('/gallery')} sx={menuItemStyle}>
-                  Gallery
+                  Archive
                 </MenuItem>
                 <MenuItem onClick={() => navigateTo('/registration')} sx={menuItemStyle}>
                   Register
@@ -113,7 +113,7 @@ function Nav() {
                   </MenuItem>
                 )}
                 <MenuItem onClick={() => navigateTo('/gallery')} sx={menuItemStyle}>
-                  Gallery
+                  Archive
                 </MenuItem>
                 <MenuItem onClick={() => navigateTo('/help')} sx={menuItemStyle}>
                   Help


### PR DESCRIPTION
## Description:
Made some changes to the Gallery page, now called Archive. Removed grid lines, rending 15 posts per page, and simplified info shown on main archive page. Clicking on a piece of evidence opens a modal with the rest of the info

<img width="1276" alt="Screen Shot 2024-11-27 at 17 07 22" src="https://github.com/user-attachments/assets/5f53105c-a9cc-41af-9594-c8f6a6215374">
<img width="963" alt="Screen Shot 2024-11-27 at 17 06 54" src="https://github.com/user-attachments/assets/c31fede3-ea75-4b65-a78c-e393069f9e0b">
